### PR TITLE
Use Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
See [GitHub Actions: All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
